### PR TITLE
Check error code instead of error message

### DIFF
--- a/src/hasura-auth-client.ts
+++ b/src/hasura-auth-client.ts
@@ -787,7 +787,7 @@ export class HasuraAuthClient {
       const { session, error } = await this.api.refreshToken({ refreshToken });
 
       if (error) {
-        if (error.message === 'Request failed with status code 401') {
+        if (error.code === 401) {
           await this._clearSession();
           return;
         }

--- a/src/hasura-auth-client.ts
+++ b/src/hasura-auth-client.ts
@@ -787,7 +787,7 @@ export class HasuraAuthClient {
       const { session, error } = await this.api.refreshToken({ refreshToken });
 
       if (error) {
-        if (error.code === 401) {
+        if (error.status === 401) {
           await this._clearSession();
           return;
         }


### PR DESCRIPTION
Instead of checking the error message, check the error code to determine if the session should be cleared